### PR TITLE
Remove unused #[feature]s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]
 
-#![feature(convert)]
-
-#![feature(log_syntax)]
-#![feature(trace_macros)]
-
 extern crate libc;
 extern crate llvm_sys;
 


### PR DESCRIPTION
Crate does not build on stable - `lib.rs` has redundant `#[feature(convert)]`, `#[feature(log_syntax)]`, and `#[feature(trace_macros)]` annotations. Removing them allows the crate to compile.