### PR TITLE
Update libc and llvm-sys dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Jauhien Piatlicki <jauhien@gentoo.org>"]
 build = "build.rs"
 
 [dependencies]
-libc = "0.1.10"
-llvm-sys = "0.2.1"
+libc = "0.2"
+llvm-sys = "0.4"
 
 [build-dependencies]
 cmake = "0.1.12"


### PR DESCRIPTION
The other PR (#4) updates to an older `llvm-sys` and also rewrites `Cargo.toml` a little. This PR updates `libc` and `llvm-sys` dependencies but also only tracks `major.minor` versions (`libc = "0.2"`, `llvm-sys = "0.4") respectively.